### PR TITLE
2.0.0 beta2

### DIFF
--- a/specifications/android.md
+++ b/specifications/android.md
@@ -1,6 +1,6 @@
 # Specifications
 
-UnifiedPush Spec: AND_2.0.0-beta1
+UnifiedPush Spec: AND_2.0.0-beta2
 
 ## Index
 
@@ -49,9 +49,12 @@ The exposed broadcast receiver of the distributor application MUST handle 2 diff
 
 ### org.unifiedpush.android.distributor.REGISTER
 
-The connector send this action to register to push messages. The intent MUST contain 2 String extras:
-* application: with the end user application package name. The distributor MUST be able to handle many connections with a single application.
-* token: with a random token to identify the connection between the connector and the distributor. It MUST be unique on distributor side.
+The connector send this action to register to push messages. The intent MUST contain 2 extras:
+* application (String): with the end user application package name. The distributor MUST be able to handle many connections with a single application.
+* token (String): with a random token to identify the connection between the connector and the distributor. It MUST be unique on distributor side.
+
+It MAY be send with the following extra:
+* features (ArrayList<String>): indicate the connector supports a set of optional features. Only "bytesMessage" is currently specified.
 
 The distributor MUST send a broadcast intent to one of the following action when it handles this action:
 * org.unifiedpush.android.connector.NEW_ENDPOINT
@@ -59,8 +62,8 @@ The distributor MUST send a broadcast intent to one of the following action when
 
 ### org.unifiedpush.android.distributor.UNREGISTER
 
-The connector send this action to unregister to push messages. The intent MUST contain 1 String extra:
-* token: the token supplied by the end user application during registration
+The connector send this action to unregister to push messages. The intent MUST contain 1 extra:
+* token (String): the token supplied by the end user application during registration
 
 The distributor MUST send a broadcast intent to the following action when it handles this action:
 * org.unifiedpush.android.connector.UNREGISTERED.
@@ -82,14 +85,14 @@ There is a third action the connector SHOULD handle:
 ### org.unifiedpush.android.connector.NEW_ENDPOINT
 
 The distributor MUST send this action to the registered application to confirm the registration of an end user application, when a registered application send again an action with the intent org.unifiedpush.android.distributor.REGISTER and a valid token, or when the endpoint change with the 2 following extras:
-* token: the token supplied by the end user application during registration
-* endpoint: the endpoint
+* token (String): the token supplied by the end user application during registration
+* endpoint (String): the endpoint
 
 ### org.unifiedpush.android.connector.REGISTRATION_FAILED
 
 The distributor MUST send this action to the registered application if the token is already registered for another application or if the registration can not be processed (for instance when the distributor is not connected to its provider server) with the 2 following extras:
-* token: the token supplied by the end user application during registration
-* message: this extra MAY be sent to gives an error message
+* token (String): the token supplied by the end user application during registration
+* message (String): this extra MAY be sent to gives an error message
 
 The connector MUST change the connection token received with this action for the next registration.
 
@@ -97,17 +100,23 @@ The connector MUST change the connection token received with this action for the
 
 The distributor MUST send this action to the registered application to forward a push message received from the provider to the end user application.
 
-It MUST be send with the 2 following extras:
-* token: the token supplied by the end user application during registration
-* message: the push message sent by the application server. It MUST be the raw POST data received by the rewrite proxy.
+It MUST be send with the following extra:
+* token (String): the token supplied by the end user application during registration
+
+It MUST be send with at least one of the 2 following extras:
+* message (String): the push message sent by the application server, as a string. It MUST be setted if the connector has been registered without support for bytesMessage feature. If setted, it MUST be the raw POST data received by the rewrite proxy.
+* bytesMessage (ByteArray): the push message sent by the application server, as an array of bytes. It MAY be ommited. If setted, it MUST be the raw POST data received by the rewrite proxy.
+
+The connector SHOULD prefer bytesMessage if it registered with support for bytesMessage feature.
 
 It MAY be send with the following extra:
-* id: to identify the message
+* id (String): to identify the message
+
 
 ### org.unifiedpush.android.connector.UNREGISTERED
 
 The distributor MUST send this action to the registered application to confirm unregistration or to inform the application about unregistration.
 
 If this action is send to inform the application, the intent MUST have the following extra:
-* token: the token supplied by the end user application during registration
+* token (String): the token supplied by the end user application during registration
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -59,7 +59,7 @@ The connector sends this action to register to push messages. The intent MUST co
 * application (String): with the end user application package name. The distributor MUST be able to handle many connections with a single application.
 * token (String): with a random token to identify the connection between the connector and the distributor. It MUST be unique on distributor side.
 
-It MAY be send with the following extra:
+It MAY be sent with following extra:
 * features (ArrayList<String>): indicate the connector is requesting a set of optional features to be enabled. It MUST be the qualified name of the action declared to advertise this feature. The connector MUST check that the action is declared before requesting an optional feature.
 
 The distributor MUST send a broadcast intent to one of the following action when it handles this action:
@@ -92,7 +92,7 @@ There is a third action the connector SHOULD handle:
 
 The distributor MUST send this action to the registered application to confirm the registration of an end user application, when a registered application send again an action with the intent org.unifiedpush.android.distributor.REGISTER and a valid token, or when the endpoint change with the 2 following extras:
 * token (String): the token supplied by the end user application during registration
-* endpoint (String): the endpoint
+* endpoint (String): the endpoint URL
 
 ### org.unifiedpush.android.connector.REGISTRATION_FAILED
 
@@ -111,14 +111,16 @@ The connector MUST change the connection token received with this action for the
 
 The distributor MUST send this action to the registered application to forward a push message received from the provider to the end user application.
 
-It MUST be send with the following extra:
+If the BYTES_MESSAGE feature was requested, it MUST send the following extras:
 * token (String): the token supplied by the end user application during registration
+* bytesMessage (ByteArray): the push message sent by the application server, as an array of bytes. It MUST be the raw POST data received by the rewrite proxy.
 
-It MUST be send with at least one of the 2 following extras:
-* message (String): the push message sent by the application server, as a string. It MUST be set if the BYTES_MESSAGE feature was not requested during registration. If set, it MUST be the raw POST data received by the rewrite proxy.
-* bytesMessage (ByteArray): the push message sent by the application server, as an array of bytes. It MAY be ommited. If set, it MUST be the raw POST data received by the rewrite proxy.
+If the BYTES_MESSAGE feature was requested, it MAY additionally send the message as a string:
+* message (String): the push message sent by the application server, as a string.
 
-The distributor MAY set message on top of bytesMessage if BYTES_MESSAGE feature was requested.
+If the BYTES_MESSAGE feature was not requested, it MUST send the following extras:
+* token (String): the token supplied by the end user application during registration
+* message (String): the push message sent by the application server, as a string.
 
 It MAY be send with the following extra:
 * id (String): to identify the message

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -62,12 +62,12 @@ The exposed broadcast receiver of the distributor application MUST handle 2 diff
 ### org.unifiedpush.android.distributor.REGISTER
 
 The connector sends this action to register to push messages. The intent MUST contain 2 extras:
-* application (String): with the end user application package name. The distributor MUST be able to handle many connections with a single application.
-* token (String): with a random token to identify the connection between the connector and the distributor. It MUST be unique on distributor side.
+* application (String): the end user application package name. The distributor MUST be able to handle many connections with a single application.
+* token (String): a randomly generated token to identify the connection between the connector and the distributor. It MUST be unique on distributor side.
 
 It MAY be sent with the following 2 extras:
 * features (ArrayList<String>): indicate the connector is requesting a set of optional features to be enabled. It MUST be the qualified name of the action declared to advertise this feature. The connector MUST check that the action is declared before requesting an optional feature.
-* message (String) : A short description of the purpose of the registration that the connector MAY show to the user.
+* message (String) : a short description of the purpose of the registration that the connector MAY show to the user.
 
 The distributor MUST send a broadcast intent to one of the following action when it handles this action:
 * org.unifiedpush.android.connector.NEW_ENDPOINT

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -21,8 +21,10 @@ The distributor MUST expose a broadcast receiver with the following actions:
 * org.unifiedpush.android.distributor.REGISTER
 * org.unifiedpush.android.distributor.UNREGISTER
 
-This broadcast receiver is the Registration Broadcast Receiver.
+The distributor MUST also expose the following action if it supports sending bytes messages:
+* org.unifiedpush.android.distributor.feature.bytesMessage
 
+This broadcast receiver is the Registration Broadcast Receiver.
 
 ## Connector Library
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -123,11 +123,11 @@ If the BYTES_MESSAGE feature was requested, it MUST send the following extras:
 * bytesMessage (ByteArray): the push message sent by the application server, as an array of bytes. It MUST be the raw POST data received by the rewrite proxy.
 
 If the BYTES_MESSAGE feature was requested, it MAY additionally send the message as a string:
-* message (String): the push message sent by the application server, as a string. This extra can't have characters with char code > 127.
+* message (String): the push message sent by the application server, as a string.
 
 If the BYTES_MESSAGE feature was not requested, it MUST send the following extras:
 * token (String): the token supplied by the end user application during registration
-* message (String): the push message sent by the application server, as a string. This extra can't have characters with char code > 127.
+* message (String): the push message sent by the application server, as a string.
 
 It MAY be send with the following extra:
 * id (String): to identify the message

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -116,11 +116,11 @@ If the BYTES_MESSAGE feature was requested, it MUST send the following extras:
 * bytesMessage (ByteArray): the push message sent by the application server, as an array of bytes. It MUST be the raw POST data received by the rewrite proxy.
 
 If the BYTES_MESSAGE feature was requested, it MAY additionally send the message as a string:
-* message (String): the push message sent by the application server, as a string.
+* message (String): the push message sent by the application server, as a string. This extra can't have characters with char code > 127.
 
 If the BYTES_MESSAGE feature was not requested, it MUST send the following extras:
 * token (String): the token supplied by the end user application during registration
-* message (String): the push message sent by the application server, as a string.
+* message (String): the push message sent by the application server, as a string. This extra can't have characters with char code > 127.
 
 It MAY be send with the following extra:
 * id (String): to identify the message

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -67,7 +67,7 @@ The connector sends this action to register to push messages. The intent MUST co
 
 It MAY be sent with the following 2 extras:
 * features (ArrayList<String>): indicate the connector is requesting a set of optional features to be enabled. It MUST be the qualified name of the action declared to advertise this feature. The connector MUST check that the action is declared before requesting an optional feature.
-* message (String) : a short description of the purpose of the registration that the connector MAY show to the user.
+* message (String): a short description of the purpose of the registration that the distributor MAY show to the user.
 
 The distributor MUST send a broadcast intent to one of the following action when it handles this action:
 * org.unifiedpush.android.connector.NEW_ENDPOINT

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -4,10 +4,16 @@ UnifiedPush Spec: AND_2.0.0-beta2
 
 ## Index
 
+* [General](#general)
 * [Distributor Application](#distributor-application)
 * [Connector Library](#connector-library)
 * [Registration Broadcast Receiver](#registration-broadcast-receiver-1)
 * [Messaging Broadcast Receiver](#messaging-broadcast-receiver-1)
+
+## General
+
+All extras typed String MUST be UTF-8 encoded.
+
 
 ## Distributor Application
 
@@ -59,8 +65,9 @@ The connector sends this action to register to push messages. The intent MUST co
 * application (String): with the end user application package name. The distributor MUST be able to handle many connections with a single application.
 * token (String): with a random token to identify the connection between the connector and the distributor. It MUST be unique on distributor side.
 
-It MAY be sent with following extra:
+It MAY be sent with the following 2 extras:
 * features (ArrayList<String>): indicate the connector is requesting a set of optional features to be enabled. It MUST be the qualified name of the action declared to advertise this feature. The connector MUST check that the action is declared before requesting an optional feature.
+* message (String) : A short description of the purpose of the registration that the connector MAY show to the user.
 
 The distributor MUST send a broadcast intent to one of the following action when it handles this action:
 * org.unifiedpush.android.connector.NEW_ENDPOINT
@@ -68,7 +75,7 @@ The distributor MUST send a broadcast intent to one of the following action when
 
 ### org.unifiedpush.android.distributor.UNREGISTER
 
-The connector send this action to unregister to push messages. The intent MUST contain 1 extra:
+The connector sends this action to unregister to push messages. The intent MUST contain 1 extra:
 * token (String): the token supplied by the end user application during registration
 
 The distributor MUST send a broadcast intent to the following action when it handles this action:
@@ -103,7 +110,7 @@ The distributor MUST send this action to the registered application if:
 
 The action contains the 2 following extras:
 * token (String): the token supplied by the end user application during registration
-* message (String): this extra MAY be sent to gives an error message
+* message (String): this extra MAY be sent to give an error message
 
 The connector MUST change the connection token received with this action for the next registration.
 


### PR DESCRIPTION
This should keep backward compatibility with both distributor and connector I believe.

EDIT: well actually it seems to also be the case on option 3 that @p1gp1g implemented, I went a bit fast ^^. So the proposal are pretty similar and mostly differ in naming, using an extra instead of an action connector side and trying to avoid splitting the spec in v1/v2 documents.