### PR TITLE
AND_2.0.0-beta3

### DIFF
--- a/specifications/android.md
+++ b/specifications/android.md
@@ -156,5 +156,5 @@ The distributor MUST send this action to the registered application to confirm u
 If this action is sent to confirm unregistration, then the distributor MUST retrieve the target application package name using the token supplied. If no registration matching the token is found, then it SHOULD use the application received with the extra application, if it is present.
 
 The intent MUST have the following extra:
-* token (String): the token supplied by the end user application during registration. If this action was triggered by a UNREGISTER action this is the token supplied in the extras of the triggering action.
+* token (String): the token supplied by the end user application during registration to inform about unregistration, or the token supplied in the extras of the UNREGISTER action to confirm unregistration.
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -56,6 +56,9 @@ This broadcast receiver is the Messaging Broadcast Receiver.
 The exposed broadcast receiver of the distributor application MUST handle 2 different actions:
 * org.unifiedpush.android.distributor.REGISTER
 * org.unifiedpush.android.distributor.UNREGISTER
+     
+There is a third action the distributor MAY handle:
+* org.unifiedpush.android.distributor.MESSAGE_ACK
 
 ### org.unifiedpush.android.distributor.REGISTER
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -151,7 +151,9 @@ It MAY be sent with the following extra:
 
 ### org.unifiedpush.android.connector.UNREGISTERED
 
-The distributor MUST send this action to the registered application to confirm unregistration or to inform the application about unregistration. If this action was triggered by an UNREGISTER action then the distributor MUST retrieve the target application name using the token supplied. If no registration matching the token is found, then it MUST use the application received with the extra application, if it is present.
+The distributor MUST send this action to the registered application to confirm unregistration (after an UNREGISTER request) or to inform the application about unregistration.
+
+If this action is sent to confirm unregistration, then the distributor MUST retrieve the target application package name using the token supplied. If no registration matching the token is found, then it SHOULD use the application received with the extra application, if it is present.
 
 The intent MUST have the following extra:
 * token (String): the token supplied by the end user application during registration. If this action was triggered by a UNREGISTER action this is the token supplied in the extras of the triggering action.

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -117,7 +117,7 @@ The distributor MUST send this action to the registered application if:
 * the registration can not be processed (for instance when the distributor is not connected to its provider server)
 * a requested feature is not supported by the distributor
 
-The action MUST contain the following 1 extra:
+The action MUST contain the following extra:
 * token (String): the token supplied by the end user application during registration
 
 The intent SHOULD contain 1 additional extra:

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -146,8 +146,8 @@ It MAY be sent with the following extra:
 
 ### org.unifiedpush.android.connector.UNREGISTERED
 
-The distributor MUST send this action to the registered application to confirm unregistration or to inform the application about unregistration.
+The distributor MUST send this action to the registered application to confirm unregistration or to inform the application about unregistration. If this action was triggered by an UNREGISTER action then the distributor MUST retrieve the application name to send the UNREGISTERED action to using the token supplied. If no registration matching the token is found, then it MUST use the application received with the extra application, if it is present.
 
 The intent MUST have the following extra:
-* token (String): the token supplied by the end user application during registration
+* token (String): the token supplied by the end user application during registration. If this action was triggered by a UNREGISTER action and no matching registration was found during its handling then this is the token supplied in the extras of the triggering action.
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -89,7 +89,7 @@ Whenever the connector receives a message with the extra id it MUST reply with t
 
 ## Messaging Broadcast Receiver
 
-The exposed broadcast receiver of the distributor application MUST handle 3 differents actions:
+The exposed broadcast receiver of the connector library MUST handle 2 differents actions:
 * org.unifiedpush.android.connector.NEW_ENDPOINT
 * org.unifiedpush.android.connector.MESSAGE
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -12,7 +12,8 @@ UnifiedPush Spec: AND_2.0.0-beta3
 
 ## General
 
-All extras typed String MUST be UTF-8 encoded.
+* All extras typed String MUST be UTF-8 encoded.
+* All required extras MUST be non-null.
 
 ## Distributor Application
 
@@ -64,7 +65,7 @@ There is a third action the distributor MAY handle:
 
 The connector sends this action to register to push messages. The intent MUST contain 2 extras:
 * application (String): the end user application package name. The distributor MUST be able to handle many registrations with a single application.
-* token (String): a randomly generated token to identify the registration from the connector and the distributor. It MUST be unique on distributor side.
+* token (String): a randomly generated token to identify the registration from the connector and the distributor. It MUST be unique on distributor side and contain sufficient entropy so it cannot be guessed.
 
 It MAY be sent with the following 2 extras:
 * features (ArrayList\<String\>): indicate the connector is requesting a set of optional features to be enabled. It MUST be the qualified name of the action declared to advertise this feature. The connector MUST check that the action is declared before requesting an optional feature.
@@ -79,15 +80,12 @@ The distributor MUST send a broadcast intent to one of the following actions whe
 The connector sends this action to unregister from push messages. The intent MUST contain 1 extra:
 * token (String): the token supplied by the end user application during registration
 
-The intent SHOULD contain 1 additional extra:
-* application (String): the end user application package name.
-
-The distributor MUST send a broadcast intent to the following action when it handles this action:
-* org.unifiedpush.android.connector.UNREGISTERED.
-
 ### org.unifiedpush.android.distributor.MESSAGE_ACK
 
-Whenever the connector receives a message with the extra id it MUST reply with this action to the distributor with the String extra id received to acknowledge the message reception.
+Whenever the connector receives a message with the extra id it MUST reply with this action to the distributor.
+
+The intent MUST contain 1 extra:
+* id (String): the String extra id received with the message
 
 ## Messaging Broadcast Receiver
 
@@ -104,7 +102,7 @@ There are 2 additional actions the connector SHOULD handle:
 The distributor MUST send this action to the registered application in the following cases:
 * confirm the registration of an end user application
 * a registered application sends an action with the intent org.unifiedpush.android.distributor.REGISTER and a token for an existing registration. The distributor MUST also update the features associated with the registration.
-* the endpoint for the application changes
+* the endpoint for the application changed
 
 The intent MUST contain the following 2 extras:
 * token (String): the token supplied by the end user application during registration
@@ -151,10 +149,7 @@ It MAY be sent with the following extra:
 
 ### org.unifiedpush.android.connector.UNREGISTERED
 
-The distributor MUST send this action to the registered application to confirm unregistration (after an UNREGISTER request) or to inform the application about unregistration.
-
-If this action is sent to confirm unregistration, then the distributor MUST retrieve the target application package name using the token supplied. If no registration matching the token is found, then it SHOULD use the application received with the extra application, if it is present.
+The distributor MUST send this action to the registered application to inform it about unregistration.
 
 The intent MUST have the following extra:
-* token (String): the token supplied by the end user application during registration to inform about unregistration, or the token supplied in the extras of the UNREGISTER action to confirm unregistration.
-
+* token (String): the token supplied by the end user application during registration

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -1,6 +1,6 @@
 # Specifications
 
-UnifiedPush Spec: AND_2.0.0-beta2
+UnifiedPush Spec: AND_2.0.0-beta3
 
 ## Index
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -84,7 +84,7 @@ The distributor MUST send a broadcast intent to the following action when it han
 
 ### org.unifiedpush.android.distributor.MESSAGE_ACK
 
-The connector MUST reply with this action to the distributor with the String extra id received to acknowledge the message reception.
+Whenever the connector receives a message with the extra id it MUST reply with this action to the distributor with the String extra id received to acknowledge the message reception.
 
 
 ## Messaging Broadcast Receiver

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -91,7 +91,7 @@ Whenever the connector receives a message with the extra id it MUST reply with t
 
 ## Messaging Broadcast Receiver
 
-The exposed broadcast receiver of the connector library MUST handle 2 differents actions:
+The exposed broadcast receiver of the end user application MUST handle 2 differents actions:
 * org.unifiedpush.android.connector.NEW_ENDPOINT
 * org.unifiedpush.android.connector.MESSAGE
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -69,13 +69,13 @@ It MAY be sent with the following 2 extras:
 * features (ArrayList\<String\>): indicate the connector is requesting a set of optional features to be enabled. It MUST be the qualified name of the action declared to advertise this feature. The connector MUST check that the action is declared before requesting an optional feature.
 * message (String): a short description of the purpose of the registration that the distributor MAY show to the user.
 
-The distributor MUST send a broadcast intent to one of the following action when it handles this action:
+The distributor MUST send a broadcast intent to one of the following actions when it handles this action:
 * org.unifiedpush.android.connector.NEW_ENDPOINT
 * org.unifiedpush.android.connector.REGISTRATION_FAILED
 
 ### org.unifiedpush.android.distributor.UNREGISTER
 
-The connector sends this action to unregister to push messages. The intent MUST contain 1 extra:
+The connector sends this action to unregister from push messages. The intent MUST contain 2 extras:
 * token (String): the token supplied by the end user application during registration
 * application (String): the end user application package name.
 
@@ -85,7 +85,6 @@ The distributor MUST send a broadcast intent to the following action when it han
 ### org.unifiedpush.android.distributor.MESSAGE_ACK
 
 Whenever the connector receives a message with the extra id it MUST reply with this action to the distributor with the String extra id received to acknowledge the message reception.
-
 
 ## Messaging Broadcast Receiver
 
@@ -98,7 +97,12 @@ There is a third action the connector SHOULD handle:
 
 ### org.unifiedpush.android.connector.NEW_ENDPOINT
 
-The distributor MUST send this action to the registered application to confirm the registration of an end user application, when a registered application send again an action with the intent org.unifiedpush.android.distributor.REGISTER and a valid token, or when the endpoint change with the 2 following extras:
+The distributor MUST send this action to the registered application in the following cases:
+* confirm the registration of an end user application
+* a registered application sends an action with the intent org.unifiedpush.android.distributor.REGISTER and a token for an existing registration
+*  the endpoint changes
+
+The intent MUST contain the following 2 extras:
 * token (String): the token supplied by the end user application during registration
 * endpoint (String): the endpoint URL
 
@@ -109,7 +113,7 @@ The distributor MUST send this action to the registered application if:
 * the registration can not be processed (for instance when the distributor is not connected to its provider server)
 * a requested feature is not supported by the distributor
 
-The action contains the 2 following extras:
+The action MUST contain the following 2 extras:
 * token (String): the token supplied by the end user application during registration
 * message (String): this extra MAY be sent to give an error message
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -146,7 +146,7 @@ It MAY be sent with the following extra:
 
 ### org.unifiedpush.android.connector.UNREGISTERED
 
-The distributor MUST send this action to the registered application to confirm unregistration or to inform the application about unregistration. If this action was triggered by an UNREGISTER action then the distributor MUST retrieve the application name to send the UNREGISTERED action to using the token supplied. If no registration matching the token is found, then it MUST use the application received with the extra application, if it is present.
+The distributor MUST send this action to the registered application to confirm unregistration or to inform the application about unregistration. If this action was triggered by an UNREGISTER action then the distributor MUST retrieve the target application name using the token supplied. If no registration matching the token is found, then it MUST use the application received with the extra application, if it is present.
 
 The intent MUST have the following extra:
 * token (String): the token supplied by the end user application during registration. If this action was triggered by a UNREGISTER action and no matching registration was found during its handling then this is the token supplied in the extras of the triggering action.

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -62,8 +62,8 @@ The exposed broadcast receiver of the distributor application MUST handle 2 diff
 ### org.unifiedpush.android.distributor.REGISTER
 
 The connector sends this action to register to push messages. The intent MUST contain 2 extras:
-* application (String): the end user application package name. The distributor MUST be able to handle many connections with a single application.
-* token (String): a randomly generated token to identify the connection between the connector and the distributor. It MUST be unique on distributor side.
+* application (String): the end user application package name. The distributor MUST be able to handle many registrations with a single application.
+* token (String): a randomly generated token to identify the registration from the connector and the distributor. It MUST be unique on distributor side.
 
 It MAY be sent with the following 2 extras:
 * features (ArrayList<String>): indicate the connector is requesting a set of optional features to be enabled. It MUST be the qualified name of the action declared to advertise this feature. The connector MUST check that the action is declared before requesting an optional feature.
@@ -113,7 +113,7 @@ The action contains the 2 following extras:
 * token (String): the token supplied by the end user application during registration
 * message (String): this extra MAY be sent to give an error message
 
-The connector MUST change the connection token received with this action for the next registration.
+The connector MUST change the registration token received with this action for the next registration.
 
 ### org.unifiedpush.android.connector.MESSAGE
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -76,8 +76,10 @@ The distributor MUST send a broadcast intent to one of the following actions whe
 
 ### org.unifiedpush.android.distributor.UNREGISTER
 
-The connector sends this action to unregister from push messages. The intent MUST contain 2 extras:
+The connector sends this action to unregister from push messages. The intent MUST contain 1 extra:
 * token (String): the token supplied by the end user application during registration
+
+The intent SHOULD contain 1 additional extra:
 * application (String): the end user application package name.
 
 The distributor MUST send a broadcast intent to the following action when it handles this action:

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -125,6 +125,8 @@ The intent SHOULD contain 1 additional extra:
 
 The connector MUST change the registration token received with this action for the next registration.
 
+If a connector receives this action after it already received a NEW_ENDPOINT action for the same token then it should ignore this action.
+
 ### org.unifiedpush.android.connector.MESSAGE
 
 The distributor MUST send this action to the registered application to forward a push message received from the provider to the end user application.

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -120,7 +120,7 @@ The distributor MUST send this action to the registered application if:
 The action MUST contain the following extra:
 * token (String): the token supplied by the end user application during registration
 
-The intent SHOULD contain 1 additional extra:
+The intent MAY contain 1 additional extra:
 * message (String): an error message describing why the registration failed
 
 The connector MUST change the registration token received with this action for the next registration.

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -149,5 +149,5 @@ It MAY be sent with the following extra:
 The distributor MUST send this action to the registered application to confirm unregistration or to inform the application about unregistration. If this action was triggered by an UNREGISTER action then the distributor MUST retrieve the target application name using the token supplied. If no registration matching the token is found, then it MUST use the application received with the extra application, if it is present.
 
 The intent MUST have the following extra:
-* token (String): the token supplied by the end user application during registration. If this action was triggered by a UNREGISTER action and no matching registration was found during its handling then this is the token supplied in the extras of the triggering action.
+* token (String): the token supplied by the end user application during registration. If this action was triggered by a UNREGISTER action this is the token supplied in the extras of the triggering action.
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -130,7 +130,10 @@ If the BYTES_MESSAGE feature was not requested, it MUST send the following extra
 * token (String): the token supplied by the end user application during registration
 * message (String): the push message sent by the application server, as a string.
 
-It MAY be send with the following extra:
+If the BYTES_MESSAGE feature was not requested, it MAY additionally send the message as a byte array:
+* bytesMessage (ByteArray): the push message sent by the application server, as a string.
+  
+It MAY be sent with the following extra:
 * id (String): to identify the message
 
 
@@ -138,6 +141,6 @@ It MAY be send with the following extra:
 
 The distributor MUST send this action to the registered application to confirm unregistration or to inform the application about unregistration.
 
-If this action is send to inform the application, the intent MUST have the following extra:
+The intent MUST have the following extra:
 * token (String): the token supplied by the end user application during registration
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -55,7 +55,7 @@ This broadcast receiver is the Messaging Broadcast Receiver.
 
 ## Registration Broadcast Receiver
 
-The exposed broadcast receiver of the distributor application MUST handle 2 differents actions:
+The exposed broadcast receiver of the distributor application MUST handle 2 different actions:
 * org.unifiedpush.android.distributor.REGISTER
 * org.unifiedpush.android.distributor.UNREGISTER
 
@@ -135,8 +135,8 @@ If the BYTES_MESSAGE feature was not requested, it MUST send the following extra
 * message (String): the push message sent by the application server, as a string.
 
 If the BYTES_MESSAGE feature was not requested, it MAY additionally send the message as a byte array:
-* bytesMessage (ByteArray): the push message sent by the application server, as a string.
-  
+* bytesMessage (ByteArray): the push message sent by the application server, as an array of bytes. It MUST be the raw POST data received by the rewrite proxy.
+
 It MAY be sent with the following extra:
 * id (String): to identify the message
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -95,8 +95,9 @@ The exposed broadcast receiver of the connector library MUST handle 2 differents
 * org.unifiedpush.android.connector.NEW_ENDPOINT
 * org.unifiedpush.android.connector.MESSAGE
 
-There is a third action the connector SHOULD handle:
+There are 2 additional actions the connector SHOULD handle:
 * org.unifiedpush.android.connector.UNREGISTERED
+* org.unifiedpush.android.connector.REGISTRATION_FAILED
 
 ### org.unifiedpush.android.connector.NEW_ENDPOINT
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -100,7 +100,7 @@ There is a third action the connector SHOULD handle:
 
 The distributor MUST send this action to the registered application in the following cases:
 * confirm the registration of an end user application
-* a registered application sends an action with the intent org.unifiedpush.android.distributor.REGISTER and a token for an existing registration
+* a registered application sends an action with the intent org.unifiedpush.android.distributor.REGISTER and a token for an existing registration. The distributor MUST also update the features associated with the registration.
 * the endpoint for the application changes
 
 The intent MUST contain the following 2 extras:

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -117,9 +117,11 @@ The distributor MUST send this action to the registered application if:
 * the registration can not be processed (for instance when the distributor is not connected to its provider server)
 * a requested feature is not supported by the distributor
 
-The action MUST contain the following 2 extras:
+The action MUST contain the following 1 extra:
 * token (String): the token supplied by the end user application during registration
-* message (String): this extra MAY be sent to give an error message
+
+The intent SHOULD contain 1 additional extra:
+* message (String): an error message describing why the registration failed
 
 The connector MUST change the registration token received with this action for the next registration.
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -66,7 +66,7 @@ The connector sends this action to register to push messages. The intent MUST co
 * token (String): a randomly generated token to identify the registration from the connector and the distributor. It MUST be unique on distributor side.
 
 It MAY be sent with the following 2 extras:
-* features (ArrayList<String>): indicate the connector is requesting a set of optional features to be enabled. It MUST be the qualified name of the action declared to advertise this feature. The connector MUST check that the action is declared before requesting an optional feature.
+* features (ArrayList\<String\>): indicate the connector is requesting a set of optional features to be enabled. It MUST be the qualified name of the action declared to advertise this feature. The connector MUST check that the action is declared before requesting an optional feature.
 * message (String): a short description of the purpose of the registration that the distributor MAY show to the user.
 
 The distributor MUST send a broadcast intent to one of the following action when it handles this action:

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -14,7 +14,6 @@ UnifiedPush Spec: AND_2.0.0-beta3
 
 All extras typed String MUST be UTF-8 encoded.
 
-
 ## Distributor Application
 
 ### Registration Broadcast Receiver
@@ -35,7 +34,6 @@ This broadcast receiver is the Registration Broadcast Receiver.
 
 The distributor MUST expose the following action if it supports sending messages as ByteArray instead of String:
 * org.unifiedpush.android.distributor.feature.BYTES_MESSAGE
-
 
 ## Connector Library
 
@@ -100,7 +98,7 @@ There is a third action the connector SHOULD handle:
 The distributor MUST send this action to the registered application in the following cases:
 * confirm the registration of an end user application
 * a registered application sends an action with the intent org.unifiedpush.android.distributor.REGISTER and a token for an existing registration
-*  the endpoint changes
+* the endpoint for the application changes
 
 The intent MUST contain the following 2 extras:
 * token (String): the token supplied by the end user application during registration
@@ -123,14 +121,14 @@ The connector MUST change the registration token received with this action for t
 
 The distributor MUST send this action to the registered application to forward a push message received from the provider to the end user application.
 
-If the BYTES_MESSAGE feature was requested, it MUST send the following extras:
+If the BYTES_MESSAGE feature was requested, it MUST send the following 2 extras:
 * token (String): the token supplied by the end user application during registration
 * bytesMessage (ByteArray): the push message sent by the application server, as an array of bytes. It MUST be the raw POST data received by the rewrite proxy.
 
 If the BYTES_MESSAGE feature was requested, it MAY additionally send the message as a string:
 * message (String): the push message sent by the application server, as a string.
 
-If the BYTES_MESSAGE feature was not requested, it MUST send the following extras:
+If the BYTES_MESSAGE feature was not requested, it MUST send the following 2 extras:
 * token (String): the token supplied by the end user application during registration
 * message (String): the push message sent by the application server, as a string.
 

--- a/specifications/android.md
+++ b/specifications/android.md
@@ -77,6 +77,7 @@ The distributor MUST send a broadcast intent to one of the following action when
 
 The connector sends this action to unregister to push messages. The intent MUST contain 1 extra:
 * token (String): the token supplied by the end user application during registration
+* application (String): the end user application package name.
 
 The distributor MUST send a broadcast intent to the following action when it handles this action:
 * org.unifiedpush.android.connector.UNREGISTERED.


### PR DESCRIPTION
- add application extra to UNREGISTER action so a distributor can answer UNREGISTERED even when not finding a matching registration
- clarify when a connector MUST send the MESSAGE_ACK
- mention the MESSAGE_ACK in the registration broadcast section
- allow the distributor to always send both message and byteMessage for simplicity
- when receiving a REGISTRATION for a token that is already existed with the same package name the distributor MUST update the features associated with the registration. Otherwise the connector would have to unregister and re-register when moving to a new connector version. This way it just has to send register on every startup
- a small mistake where we wrote distributor instead of connector
- some language consistency and clarification