### PR TITLE
Make server success code match webpush

### DIFF
--- a/specifications/server.md
+++ b/specifications/server.md
@@ -28,7 +28,7 @@ The body and headers of a push response can be ignored.
 
 #### 2xx
 
-The push provider MUST return a status code from 200-299 if it successfully accepts the notification. This SHOULD be the code 202. Note that this is independent of the end-user application receiving the push.
+The push provider MUST return a status code from 200-299 if it successfully accepts the notification. This SHOULD be the code 201. Note that this is independent of the end-user application receiving the push.
 
 In this case, the distributor MUST send EXACTLY the contents of the HTTP POST request to the connector library.
 


### PR DESCRIPTION
Changing 202 to 201 is a very insignificant change since 2xx is required to be accepted (and most webpush implementations accept 2xx anyway https://github.com/UnifiedPush/wishlist/issues/15#issuecomment-1086995693)

However, it is a minor way in which UnifiedPush can be similar to WebPush and could matter to pickier implementations. 201 is required in webpush. https://datatracker.ietf.org/doc/html/rfc8030#section-5